### PR TITLE
Fixed bug when using boolean value annotations with deploy

### DIFF
--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -73,7 +73,8 @@ try {
   for (let annotation of [...(argv.annotation || [])]) {
     const index = annotation.indexOf('=')
     if (index < 0) throw Error('Annotation syntax must be "KEY=VALUE"')
-    composition.annotations.push({ key: annotation.substring(0, index), value: annotation.substring(index + 1) })
+    const value = annotation.substring(index + 1);
+    composition.annotations.push({ key: annotation.substring(0, index), value: (value === "true") ? true : value })
   }
   if (typeof argv['annotation-file'] === 'string') argv['annotation-file'] = [argv['annotation-file']]
   for (let annotation of argv['annotation-file'] || []) {

--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -73,7 +73,7 @@ try {
   for (let annotation of [...(argv.annotation || [])]) {
     const index = annotation.indexOf('=')
     if (index < 0) throw Error('Annotation syntax must be "KEY=VALUE"')
-    const value = annotation.substring(index + 1);
+    const value = annotation.substring(index + 1).toLowerCase();
     composition.annotations.push({ key: annotation.substring(0, index), value: (value === "true") ? true : value })
   }
   if (typeof argv['annotation-file'] === 'string') argv['annotation-file'] = [argv['annotation-file']]


### PR DESCRIPTION
Currently if you try and use a boolean valued annotation with the deploy command the value is treated as a string and not a boolean. 

For example
```
deploy aio-tests-0.0.1/test-composer actions/test-composer/index.json -w --annotation web-export=true 
```

Results in the web-export being set to 'true' and not the boolean value true. The web-export annotation does not work if the value is set to 'true'

![Screen Shot 2020-03-17 at 11 14 43 AM](https://user-images.githubusercontent.com/3231084/76870771-84987100-6840-11ea-8f91-a6460f86c1b6.png)

This PR attempts to fix that.